### PR TITLE
not pass in job_name from airflow

### DIFF
--- a/airflow/contrib/hooks/gcp_dataflow_hook.py
+++ b/airflow/contrib/hooks/gcp_dataflow_hook.py
@@ -178,7 +178,7 @@ class DataFlowHook(GoogleCloudBaseHook):
 
     def start_python_dataflow(self, task_id, variables, dataflow, py_options):
         name = task_id + "-" + str(uuid.uuid1())[:8]
-        variables["job_name"] = name
+        #variables["job_name"] = name
 
         def label_formatter(labels_dict):
             return ['--labels={}={}'.format(key, value)


### PR DESCRIPTION
We skip passing in job_name to dataflow in airflow.  Otherwise this will prevent to run multiple jobs inside the airflow job.
