### PR TITLE
use string not bool

### DIFF
--- a/airflow/contrib/operators/kubernetes_operator.py
+++ b/airflow/contrib/operators/kubernetes_operator.py
@@ -182,7 +182,7 @@ class KubernetesJobOperator(BaseOperator):
         instance_env['AIRFLOW_DAG_ID'] = self.dag_id
         instance_env['AIRFLOW_TASK_ID'] = self.task_id
         instance_env['AIRFLOW_EXECUTION_DATE'] = context['execution_date'].isoformat()
-        instance_env['AIRFLOW_ENABLE_XCOM_PICKLING'] = configuration.getboolean('core', 'enable_xcom_pickling')
+        instance_env['AIRFLOW_ENABLE_XCOM_PICKLING'] = str(configuration.getboolean('core', 'enable_xcom_pickling'))
         instance_env['KUBERNETES_JOB_NAME'] = unique_job_name
 
         # Make a copy of all the containers.


### PR DESCRIPTION
boolean makes yaml validation fail

[2018-05-15 22:30:11,479] {logging_mixin.py:93} INFO - [2018-05-15 22:30:11,478] {base_task_runner.py:98} INFO - Subtask: error: error validating "/tmp/tmpiybipt.yaml": error validating data: expected type string, for field spec.template.spec.containers[0].env[4].value, got bool; if you choose to ignore these errors, turn validation off with --validate=false