### PR TITLE
Adding `--forwarded-allow-ips *` to the gunicorn invocation

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -726,7 +726,8 @@ def webserver(args):
             '-b', args.hostname + ':' + str(args.port),
             '-n', 'airflow-webserver',
             '-p', str(pid),
-            '-c', 'airflow.www.gunicorn_config'
+            '-c', 'airflow.www.gunicorn_config',
+            '--forwarded-allow-ips', '*',
         ]
 
         if args.access_logfile:
@@ -757,6 +758,8 @@ def webserver(args):
             else:
                 while True:
                     time.sleep(1)
+
+        print("Starting server: " + ' '.join(run_args))
 
         if args.daemon:
             base, ext = os.path.splitext(pid)

--- a/airflow/contrib/hooks/gcp_api_base_hook.py
+++ b/airflow/contrib/hooks/gcp_api_base_hook.py
@@ -86,7 +86,7 @@ class GoogleCloudBaseHook(BaseHook, LoggingMixin):
                 raise AirflowException('Legacy P12 key file are not supported, '
                                        'use a JSON key file.')
             else:
-                raise AirflowException('Unrecognised extension for key file.')
+                raise AirflowException('Unrecognised extension for key file: %s.' % key_path)
         else:
             if not scope:
                 raise AirflowException('Scope should be defined when using key JSON.')


### PR DESCRIPTION
GUnicorn, by default, expects that proxies will be on the same box. Because we have Google's load balancers terminating TLS, which is off-box, GUnicorn is not respecting the `X-Forwarded-Proto` header. Adding this parameter tells GUnicorn that it should respect `X-Forwarded-Proto` regardless. This is not always good because a malicious client could theoretically downgrade to HTTP. In our case, the fact that Google is terminating TLS for us will prevent a client from doing anything cute -- they can _request_ HTTP, but it won't work.

https://bluecore.atlassian.net/browse/PROD-12041
https://bluecore.atlassian.net/browse/PROD-7793