### PR TITLE
Created AppEngineOperatorSync, renamed AEOv2 to AppEngineOperatorAsync

### DIFF
--- a/airflow/contrib/operators/app_engine_operator.py
+++ b/airflow/contrib/operators/app_engine_operator.py
@@ -5,9 +5,13 @@ from airflow.hooks.http_hook import HttpHook
 from airflow.models import BaseOperator, XCOM_RETURN_KEY
 from airflow.utils.decorators import apply_defaults
 from datetime import datetime
-import json
+try:
+    import ujson as json
+except ImportError:
+    import json
 import logging
 import time
+import yaml
 
 
 class AppEngineOperator(BaseOperator):
@@ -74,25 +78,79 @@ def check_gcs_file_exists(file_name, google_cloud_conn_id, bucket):
 # TODO test jinja render job id correctly
 
 
-class AppEngineOperatorV2(BaseOperator):
-    template_fields = ('command_params', 'job_id',)
+class AppEngineOperatorSync(BaseOperator):
+    template_fields = ('command_name', 'command_params', 'job_id',)
 
     @apply_defaults
     def __init__(self,
                  task_id,
-                 http_conn_id,
-                 bucket,
+                 command_name,
                  command_params,
-                 job_id,
-                 google_cloud_conn_id='google_cloud_storage_default',
+                 http_conn_id='http_default',
                  **kwargs):
-        super(AppEngineOperatorV2, self).__init__(task_id=task_id, **kwargs)
+        super(AppEngineOperatorSync, self).__init__(task_id=task_id, **kwargs)
         self.http_conn_id = http_conn_id
-        self.bucket = bucket
-        command_params['job_id'] = job_id
+        self.command_name = command_name
         self.command_params = command_params
-        self.job_id = job_id
-        self.google_cloud_conn_id = google_cloud_conn_id
+
+    def execute(self, context):
+        hook = HttpHook(
+            method='POST',
+            http_conn_id=self.http_conn_id)
+
+        headers = {
+            'content-type': 'application/json',
+            'Accept': 'application/json',
+            # these are not necessary, but may make debugging easier later
+            'X-Airflow-Dag-Id': self.dag_id,
+            'X-Airflow-Task-Id': self.task_id,
+            'X-Airflow-Execution-Date': context['execution_date'].isoformat(),
+        }
+
+        if configuration.get('mysql', 'host') is not None:
+            headers['X-Airflow-Mysql-Host'] = configuration.get('mysql', 'host')
+
+        if configuration.get('mysql', 'cloudsql_instance') is not None:
+            headers['X-Airflow-Mysql-Cloudsql-Instance'] = configuration.get('mysql', 'cloudsql_instance')
+
+        # this will throw on any 4xx or 5xx
+        with hook.run(
+            endpoint='/api/airflow/sync/%s' % self.command_name,
+            headers=headers,
+            data=json.dumps(self.command_params),
+            extra_options=None
+        ) as response:
+            if response.content:
+                # be careful of content types with an encoding suffix
+                content_type = response.headers['Content-Type'].split(';')[0]
+                if content_type == 'application/json':
+                    body = response.json
+                elif content_type == 'text/plain':
+                    body = response.text
+                elif content_type in {
+                    'text/yaml', 'text/x-yaml', 'text/vnd.yaml', 'application/yaml', 'application/x-yaml'
+                }:
+                    body = yaml.load(response.text)
+                else:
+                    body = response.content
+
+                self.xcom_push(context=context, key=XCOM_RETURN_KEY, value=body)
+
+
+class AppEngineOperatorAsync(BaseOperator):
+    template_fields = ('command_name', 'command_params', 'job_id',)
+
+    @apply_defaults
+    def __init__(self,
+                 task_id,
+                 command_name,
+                 command_params,
+                 http_conn_id='http_default',
+                 **kwargs):
+        super(AppEngineOperatorAsync, self).__init__(task_id=task_id, **kwargs)
+        self.http_conn_id = http_conn_id
+        self.command_name = command_name
+        self.command_params = command_params
 
     def schedule_job(self, context):
         hook = HttpHook(
@@ -118,7 +176,7 @@ class AppEngineOperatorV2(BaseOperator):
             headers['X-Airflow-Mysql-Cloudsql-Instance'] = configuration.get('mysql', 'cloudsql_instance')
 
         hook.run(
-            endpoint='/api/airflow/schedule_job',
+            endpoint='/api/airflow/async/%s' % self.command_name,
             headers=headers,
             data=json.dumps(self.command_params),
             extra_options=None)

--- a/airflow/contrib/operators/app_engine_operator.py
+++ b/airflow/contrib/operators/app_engine_operator.py
@@ -79,6 +79,11 @@ def check_gcs_file_exists(file_name, google_cloud_conn_id, bucket):
 
 
 class AppEngineOperatorSync(BaseOperator):
+    """
+    AppEngineOperatorSync calls an API endpoint in App Engine and waits for a response. If the response has a 4xx or 5xx
+    status, the task is considered failed. If a body is included in the response, it will be stored in the
+    `return_value` XCom. JSON and YAML will be deserialized automatically.
+    """
     template_fields = ('command_name', 'command_params', 'job_id',)
 
     @apply_defaults
@@ -138,6 +143,10 @@ class AppEngineOperatorSync(BaseOperator):
 
 
 class AppEngineOperatorAsync(BaseOperator):
+    """
+    AppEngineOperatorAsync schedules a command on the App Engine task queue. Task completion is signalled by setting
+    the `return_value` in the command. If the return value is not set by the command, this will time out after an hour.
+    """
     template_fields = ('command_name', 'command_params', 'job_id',)
 
     @apply_defaults

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3537,7 +3537,7 @@ class DAG(BaseDag, LoggingMixin):
         d['is_picklable'] = True
         try:
             dttm = datetime.utcnow()
-            pickled = pickle.dumps(self)
+            pickled = pickle.dumps(self, pickle.HIGHEST_PROTOCOL)
             d['pickle_len'] = len(pickled)
             d['pickling_duration'] = "{}".format(datetime.utcnow() - dttm)
         except Exception as e:
@@ -4073,7 +4073,7 @@ class XCom(Base, LoggingMixin):
             enable_pickling = configuration.getboolean('core', 'enable_xcom_pickling')
 
         if enable_pickling:
-            value = pickle.dumps(value)
+            value = pickle.dumps(value, pickle.HIGHEST_PROTOCOL)
         else:
             try:
                 value = json.dumps(value).encode('UTF-8')


### PR DESCRIPTION
* Cleaned up the interface
* Passes the command and sync state in the URL
    * /api/airflow/(sync|async)/<command_name>
* New sync version for short App Engine calls
    * POSTs synchronously over HTTP(S)
    * If a response is provided, it will be loaded as the `return_value` XCom
        * JSON and YAML are deserialized
        * text/plain is stored as text
        * Other values are stored as binary
* Set XCom to pickle using `HIGHEST_PROTOCOL` because I was way too annoyed
