### PR TITLE
Created AppEngineOperatorSync, renamed AEOv2 to AppEngineOperatorAsync (dev->master)

### DIFF
--- a/airflow/contrib/operators/kubernetes_operator.py
+++ b/airflow/contrib/operators/kubernetes_operator.py
@@ -284,6 +284,7 @@ class KubernetesJobOperator(BaseOperator):
         instance_env['AIRFLOW_ENABLE_XCOM_PICKLING'] = configuration.getboolean('core', 'enable_xcom_pickling')
         instance_env['KUBERNETES_JOB_NAME'] = unique_job_name
         instance_env['AIRFLOW_MYSQL_HOST'] = '127.0.0.1'
+        instance_env['AIRFLOW_MYSQL_DB'] = configuration.getboolean('mysql', 'db')
         instance_env['AIRFLOW_MYSQL_USERNAME'] = KubernetesSecretParameter(
             secret_key_name='airflow-cloudsql-db-credentials',
             secret_key_key='username'


### PR DESCRIPTION
* Cleaned up the interface
* Passes the command and sync state in the URL
    * /api/airflow/(sync|async)/<command_name>
* New sync version for short App Engine calls
    * POSTs synchronously over HTTP(S)
    * If a response is provided, it will be loaded as the `return_value` XCom
        * JSON and YAML are deserialized
        * text/plain is stored as text
        * Other values are stored as binary
* Set XCom to pickle using `HIGHEST_PROTOCOL` because I was way too annoyed