### PR TITLE
Adding support for caller-specified volumes in KubernetesJobOperator

### DIFF
--- a/airflow/contrib/operators/kubernetes_operator.py
+++ b/airflow/contrib/operators/kubernetes_operator.py
@@ -141,10 +141,7 @@ class KubernetesJobOperator(BaseOperator):
             cs['env'] = env
             container_specs.append(cs)
 
-        if 'volumes' in job_data['spec']['template']['spec']:
-            volumes = job_data['spec']['template']['spec']['volumes']
-        else:
-            volumes = []
+        volumes = job_data['spec']['template']['spec'].get('volumes', [])
 
         return KubernetesJobOperator(
             job_name,

--- a/airflow/contrib/operators/kubernetes_operator.py
+++ b/airflow/contrib/operators/kubernetes_operator.py
@@ -348,21 +348,21 @@ class KubernetesJobOperator(BaseOperator):
                 'readOnly': True}]
         })
 
-        volumes = [{
+        instance_volumes = [{
             'name': 'airflow-cloudsql-instance-credentials',
             'secret': {'secretName': 'airflow-cloudsql-instance-credentials'}
         }]
 
         if self.service_account_secret_name is not None:
-            volumes.append({
+            instance_volumes.append({
                 'name': self.service_account_secret_name,
                 'secret': {'secretName': self.service_account_secret_name},
             })
 
-        skip_names = {v['name'] for v in volumes}
+        skip_names = {v['name'] for v in instance_volumes}
         for v in self.volumes:
             if v['name'] not in skip_names:
-                volumes.append(v)
+                instance_volumes.append(v)
 
         kub_job_dict = {
             'apiVersion': 'batch/v1',
@@ -372,7 +372,7 @@ class KubernetesJobOperator(BaseOperator):
                 'template': {
                     'spec': {
                         'containers': instance_containers,
-                        'volumes': volumes,
+                        'volumes': instance_volumes,
                         'restartPolicy': 'Never'
                     }
                 },


### PR DESCRIPTION
* Volumes taken in as a list of dictionaries as defined in the [API docs](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#volume-v1-core)
* `airflow-cloudsql-instance-credentials` and the volume for the `service_account_secret` are special and will overwrite provided values
* Volumes specified in yaml for `from_job_yaml` are preserved

https://bluecore.atlassian.net/browse/PROD-12260