### PR TITLE
Adding Fernet key to AppEngineOperator requests

### DIFF
--- a/airflow/contrib/operators/app_engine_operator.py
+++ b/airflow/contrib/operators/app_engine_operator.py
@@ -40,7 +40,11 @@ class AppEngineOperator(BaseOperator):
             http_conn_id=self.http_conn_id)
         hook.run(
             endpoint='/api/airflow/schedule_job',
-            headers={'content-type': 'application/json', 'Accept': 'text/plain'},
+            headers={
+                'content-type': 'application/json',
+                'Accept': 'text/plain',
+                'X-Airflow-Fernet-Key': configuration.get('core', 'fernet_key'),
+            },
             data=json.dumps(self.command_params),
             extra_options=None)
 
@@ -110,6 +114,7 @@ class AppEngineOperatorSync(BaseOperator):
             'X-Airflow-Dag-Id': self.dag_id,
             'X-Airflow-Task-Id': self.task_id,
             'X-Airflow-Execution-Date': context['execution_date'].isoformat(),
+            'X-Airflow-Fernet-Key': configuration.get('core', 'fernet_key'),
         }
 
         if configuration.get('mysql', 'host') is not None:
@@ -176,6 +181,7 @@ class AppEngineOperatorAsync(BaseOperator):
             'X-Airflow-Mysql-Db': configuration.get('mysql', 'db'),
             'X-Airflow-Mysql-User': configuration.get('mysql', 'username'),
             'X-Airflow-Mysql-Password': configuration.get('mysql', 'password'),
+            'X-Airflow-Fernet-Key': configuration.get('core', 'fernet_key'),
         }
 
         if configuration.get('mysql', 'host') is not None:


### PR DESCRIPTION
* This is required to handle Airflow variables from AppEngine
* See https://cryptography.io/en/latest/fernet/ for details

https://bluecore.atlassian.net/browse/PROD-12320

_cherry-pick from dev_