### PR TITLE
Dev -> Master

### DIFF
--- a/airflow/contrib/operators/kubernetes_operator.py
+++ b/airflow/contrib/operators/kubernetes_operator.py
@@ -54,6 +54,8 @@ class KubernetesJobOperator(BaseOperator):
         :param sleep_seconds_between_polling: number of seconds to sleep between polling
             for job completion, defaults to 60
         :type sleep_seconds_between_polling: int
+        :param cloudsql_connections: A list of CloudSQLConnection to tell cloudsql_proxy to open additional connections
+        :type cloudsql_connections: list[CloudSQLConnection]
         :param do_xcom_push: return the stdout which also get set in xcom by airflow platform
         :type do_xcom_push: bool
         """

--- a/airflow/contrib/utils/kubernetes_utils.py
+++ b/airflow/contrib/utils/kubernetes_utils.py
@@ -206,6 +206,9 @@ def deuniquify_job_name(unique_job_name):
 # you specify `port_key=MY_DB_PORT` here, in your operator you should connect using
 # `MySQLdb.connect(..., port=os.environ['MY_DB_PORT'])`
 #
+# For the connection to work, the service account used by the Cloud SQL Proxy (airflow-cloudsql-instance-credentials)
+# must have access to talk to the target database.
+#
 # :param fully_qualified_instance: project:region:name to connect to
 # :param port_key: name of environment variable where the connection port should be found
 CloudSQLConnection = namedtuple('CloudSQLConnection', ['fully_qualified_instance', 'port_key'])

--- a/airflow/contrib/utils/kubernetes_utils.py
+++ b/airflow/contrib/utils/kubernetes_utils.py
@@ -3,6 +3,7 @@ import jinja2
 
 from airflow.contrib.utils.parameters import enumerate_parameters
 from airflow.utils.helpers import is_container
+from collections import namedtuple
 from datetime import datetime
 import hashlib
 import re
@@ -197,3 +198,14 @@ def deuniquify_job_name(unique_job_name):
     :return: Name without unique garbage
     """
     return re.sub('^(.+)-[0-9a-f]{16}-[0-9a-f]{12,16}$', '\\1', unique_job_name)
+
+
+# Information for additional CloudSQL connections to open in the proxy. The KubernetesJobOperator will assign
+# a TCP port for each connection, putting the value of that selection into the environment variable specified
+# by port_key. Consumers are expected to read that environment variable when making their connection. E.g. if
+# you specify `port_key=MY_DB_PORT` here, in your operator you should connect using
+# `MySQLdb.connect(..., port=os.environ['MY_DB_PORT'])`
+#
+# :param fully_qualified_instance: project:region:name to connect to
+# :param port_key: name of environment variable where the connection port should be found
+CloudSQLConnection = namedtuple('CloudSQLConnection', ['fully_qualified_instance', 'port_key'])

--- a/airflow/contrib/utils/statsd_adapter.py
+++ b/airflow/contrib/utils/statsd_adapter.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import
+
+from statsd import StatsClient
+
+import logging
+
+
+_log = logging.getLogger(__name__)
+
+
+class StatsdAdapter(object):
+    """
+    This adapter allows us to pass tags to stats loggers that support tags (e.g. DogStatsD), while
+    instead swallowing those tags for the loggers that _don't_ support tags (e.g. statsd.StatsClient)
+    """
+    def __init__(self, inner):
+        self._inner = inner
+
+    def timer(self, stat, rate=1, tags=None):
+        self._inner.timed(stat=stat, rate=rate)
+
+    def timing(self, stat, delta, rate=1, tags=None):
+        """Send new timing information. `delta` is in milliseconds."""
+        self._inner.timing(stat=stat, delta=delta, rate=rate)
+
+    def incr(self, stat, count=1, rate=1, tags=None):
+        """Increment a stat by `count`"""
+        self._inner.increment(metric=stat, value=count, sample_rate=rate)
+
+    def decr(self, stat, count=1, rate=1, tags=None):
+        """Decrement a stat by `count`"""
+        self._inner.decrement(metric=stat, value=count, sample_rate=rate)
+
+    def gauge(self, stat, value, rate=1, delta=False, tags=None):
+        """Set a gauge value"""
+        self._inner.gauge(metric=stat, value=value, sample_rate=rate)
+
+    def set(self, stat, value, rate=1, tags=None):
+        """Set a set value"""
+        self._inner.set(metric=stat, value=value, sample_rate=rate)
+
+    def histogram(self, stat, value, rate=1, tags=None):
+        """This is not supported by statsd.StatsClient. Use with caution!"""
+        _log.warning("Histograms are not supported by statsd")

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4591,8 +4591,8 @@ class DagRun(Base, LoggingMixin):
                     break
 
         duration = (datetime.utcnow() - start_dttm).total_seconds() * 1000
-        Stats.timing("dagrun.dependency-check.{}.{}".
-                     format(self.dag_id, self.execution_date), duration)
+        Stats.timing("dagrun.dependency-check.{}".
+                     format(self.dag_id), duration)
 
         # future: remove the check on adhoc tasks (=active_tasks)
         if len(tis) == len(dag.active_tasks):


### PR DESCRIPTION
# Adding tag support to stats

https://bluecore.atlassian.net/browse/PROD-13444

StatsD doesn't support tags, but we really want success/failure stats on a per task or per dag basis. This was accomplished by adding a tag-ignoring wrapper on top the StatsClient. Ironically, we now have the distinction of using a stats interface that matches neither statsd nor dogstatsd.

___NOTE:___ _WE DO NOT SUPPORT STATS IN DEV OR QA, SO THIS CANNOT BE TESTED!_

# Support for multiple connections in the KubernetesJobOperator sidecar

This isn't used in PROD yet, but is a backwards compatible chain
