### PR TITLE
Add command params as template field for appengine operators

### DIFF
--- a/airflow/contrib/operators/app_engine_operator.py
+++ b/airflow/contrib/operators/app_engine_operator.py
@@ -109,7 +109,7 @@ class AppEngineOperatorSync(BaseOperator):
     :param kwargs: Named parameters to pass to BaseOperator constructor
     :type kwargs: dict
     """
-    template_fields = ('command_name',)
+    template_fields = ('command_name', 'command_params')
 
     @apply_defaults
     def __init__(self,
@@ -191,7 +191,7 @@ class AppEngineOperatorAsync(BaseOperator):
     :param kwargs: Named parameters to pass to BaseOperator constructor
     :type kwargs: dict
     """
-    template_fields = ('command_name',)
+    template_fields = ('command_name', 'command_params')
 
     @apply_defaults
     def __init__(self,
@@ -335,4 +335,3 @@ class AppEngineOperatorAsync(BaseOperator):
             raise
         finally:
             logging.info("Completed execute")
-


### PR DESCRIPTION
This PR makes it possible to pass in task instance variables to appengine operators as command parameters via "macros" and jinja templates: 
https://airflow.readthedocs.io/en/latest/tutorial.html#templating-with-jinja

This means the values we pass a jinja string "template" into `command_params`, and before the task actually operates, it'll render the strings.

Enabling something like:
```
execution_date = "{{ ds }}"

query_task = AppEngineOperatorSync(
    task_id='{}_query_task_{}'.format(job_prefix, partner),
    command_name='engine.campaign_tools.commands.AirflowParseWidgetProductOpenDataSinglePartner',
    command_params={'namespace': partner, 'date': execution_date}
)
```

(`{{ `ds`  }}` is a very commonly used variable)

When you specify `command_params` as a `template_field`, if the value passed into that argument isn't a string, but a dict, airflow loops through the key/values, and attempts to render all nested values.

You can [see this in action on the `PythonOperator`](https://airflow.apache.org/_modules/airflow/operators/python_operator.html) which doesn't do anything special. This functionality is [native to the `BaseOperator`](https://airflow.apache.org/_modules/airflow/models.html#BaseOperator.render_template_from_field)

I still don't know how to test this though :( 