### PR TITLE
pin pandas

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -230,7 +230,7 @@ def do_setup():
             'lxml>=3.6.0, <4.0',
             'markdown>=2.5.2, <3.0',
             'oauthlib>=2.0, <3.0',
-            'pandas>=0.17.1, <1.0.0',
+            'pandas>=0.17.1, <0.24.0',
             'psutil>=4.2.0, <5.0.0',
             'pygments>=2.0.1, <3.0',
             'python-daemon>=2.1.1, <2.2',


### PR DESCRIPTION
Pandas 0.24 was released recently, and it no longer has a `tools.merge` module:
https://github.com/pandas-dev/pandas/tree/v0.23.4/pandas
https://github.com/pandas-dev/pandas/tree/v0.24.0/pandas

so we're getting this error for dags with `BigQueryOperators`:
<img width="972" alt="continuous_integration_and_deployment" src="https://user-images.githubusercontent.com/10873141/51867269-1bdaf600-2319-11e9-9665-b097be66c3e1.png">

So we need to pin pandas to < .24

I tried to test this fix in the dev environment, but when I create a dag with a BigQueryOperator in dev, circleci seems to not pull from this repository's `dev` branch: https://circleci.com/gh/TriggerMail/airflow-dag/2051?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

though I believe this should work, as the change does successfully bring the pandas version down to .23.4
(screenshot of our dev airflow environment's pip freeze):
<img width="303" alt="1__spells_stephens-macbook-pro___src_kube-airflow__zsh__and_pin_pandas_by_spells24_ _pull_request__155_ _triggermail_incubator-airflow" src="https://user-images.githubusercontent.com/10873141/51867186-d3bbd380-2318-11e9-8c78-01a25b9c4832.png">

I will test deploying this to QA before production obviously
