### PR TITLE
PROD-21235 Pin celery version to avoid known regression tracked in celery/issues/3802

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ async = [
 azure = ['azure-storage>=0.34.0']
 sendgrid = ['sendgrid>=5.2.0']
 celery = [
-    'celery>=4.0.0',
+    'celery==4.1.1',
     'flower>=0.7.3'
 ]
 cgroups = [


### PR DESCRIPTION
Pin celery version to 4.1.1

source:
https://github.com/celery/celery/issues/3802