### PR TITLE
Revert "PROD-21235 Pin celery version to avoid known regression tracked in celery/issues/3802"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ async = [
 azure = ['azure-storage>=0.34.0']
 sendgrid = ['sendgrid>=5.2.0']
 celery = [
-    'celery==4.1.1',
+    'celery>=4.0.0',
     'flower>=0.7.3'
 ]
 cgroups = [


### PR DESCRIPTION
Reverts TriggerMail/incubator-airflow#206 because of:
https://github.com/celery/celery/commit/ec1fd31e9baed79d54c3e36b5f5d37e6e70a246f