### PR TITLE
[PROD-26871] Kill unfinished tasks when dagrun is manually changed to DagRun.state

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -71,7 +71,7 @@ from airflow.ti_deps.deps.prev_dagrun_dep import PrevDagrunDep
 from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep
 from airflow.ti_deps.deps.task_concurrency_dep import TaskConcurrencyDep
 
-from airflow.ti_deps.dep_context import DepContext, QUEUE_DEPS, RUN_DEPS
+from airflow.ti_deps.dep_context import DepContext, QUEUE_DEPS, RUN_DEPS, SCHEDULER_DEPS
 from airflow.utils.dates import cron_presets, date_range as utils_date_range
 from airflow.utils.db import provide_session
 from airflow.utils.decorators import apply_defaults
@@ -4734,22 +4734,21 @@ class DagRun(Base, LoggingMixin):
     def get_state(self):
         return self._state
 
-    def _fail_unfinished_tasks(self):
-        unfinished_tasks = self.get_task_instances(state=State.unfinished())
+    @provide_session
+    def fail_unfinished_tasks(self, session=None):
+        unfinished_tasks = self.get_task_instances(state=State.unfinished(), session=session)
         for ut in unfinished_tasks:
-            deps_met = ut.are_dependencies_met(
-                dep_context=DepContext(
-                    flag_upstream_failed=True,
-                    ignore_in_retry_period=True)
-            )
-            if not deps_met:
-                ut.set_state(State.FAILED)
+            # deps_met = ut.are_dependencies_met(
+            #     dep_context=DepContext(deps=SCHEDULER_DEPS)
+            # )
+            # if not deps_met:
+            ut.set_state(State.FAILED, session=None)
 
     def set_state(self, state):
         if self._state != state:
             self._state = state
-            if state == State.FAILED:
-                self._fail_unfinished_tasks()
+            # if state == State.FAILED:
+            #     self._fail_unfinished_tasks()
             if self.dag_id is not None:
                 # FIXME: Due to the scoped_session factor we we don't get a clean
                 # session here, so something really weird goes on:

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -83,7 +83,7 @@ from airflow.utils.state import State
 from airflow.utils.timeout import timeout
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.log.logging_mixin import LoggingMixin
-from flask import g
+from flask import request
 Base = declarative_base()
 ID_LEN = 250
 XCOM_RETURN_KEY = 'return_value'
@@ -4735,7 +4735,7 @@ class DagRun(Base, LoggingMixin):
         return self._state
 
     def _fail_unfinished_tasks(self, target_state):
-        print('flask-g {}'.format(g))
+        print('flask-request {}'.format(dir(request)))
         # hack to see if this dagrun has manually been marked through the UI.
         # if so, we also want to update the unfinished tasks
         if 'edit_view' not in '\n'.join(traceback.format_stack()):

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4734,15 +4734,14 @@ class DagRun(Base, LoggingMixin):
     def get_state(self):
         return self._state
 
-    @provide_session
-    def _fail_unfinished_tasks(self, target_state, session=None):
+    def _fail_unfinished_tasks(self, target_state):
         # hack to see if this dag has manually been marked as failed through the UI.
         # if so, we also want to fail unfinished tasks
         if 'edit_view' not in '\n'.join(traceback.format_stack()):
             return
-        unfinished_tasks = self.get_task_instances(state=State.unfinished(), session=session)
+        unfinished_tasks = self.get_task_instances(state=State.unfinished())
         for ut in unfinished_tasks:
-            ut.set_state(target_state, session=session)
+            ut.set_state(target_state)
 
     def set_state(self, state):
         if self._state != state:

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -71,7 +71,7 @@ from airflow.ti_deps.deps.prev_dagrun_dep import PrevDagrunDep
 from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep
 from airflow.ti_deps.deps.task_concurrency_dep import TaskConcurrencyDep
 
-from airflow.ti_deps.dep_context import DepContext, QUEUE_DEPS, RUN_DEPS, SCHEDULER_DEPS
+from airflow.ti_deps.dep_context import DepContext, QUEUE_DEPS, RUN_DEPS
 from airflow.utils.dates import cron_presets, date_range as utils_date_range
 from airflow.utils.db import provide_session
 from airflow.utils.decorators import apply_defaults

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4735,8 +4735,8 @@ class DagRun(Base, LoggingMixin):
         return self._state
 
     def _fail_unfinished_tasks(self, target_state):
-        # hack to see if this dag has manually been marked as failed through the UI.
-        # if so, we also want to fail unfinished tasks
+        # hack to see if this dagrun has manually been marked through the UI.
+        # if so, we also want to update the unfinished tasks
         if 'edit_view' not in '\n'.join(traceback.format_stack()):
             return
         unfinished_tasks = self.get_task_instances(state=State.unfinished())

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4737,6 +4737,7 @@ class DagRun(Base, LoggingMixin):
     def _fail_unfinished_tasks(self, target_state):
         print('flask-request-dir {}'.format(dir(request)))
         print('flask-request-p {}'.format(request))
+        print('flask-request-url {}'.format(request.url))
         # hack to see if this dagrun has manually been marked through the UI.
         # if so, we also want to update the unfinished tasks
         if 'edit_view' not in '\n'.join(traceback.format_stack()):

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4735,7 +4735,8 @@ class DagRun(Base, LoggingMixin):
         return self._state
 
     def _fail_unfinished_tasks(self, target_state):
-        print('flask-request {}'.format(dir(request)))
+        print('flask-request-dir {}'.format(dir(request)))
+        print('flask-request-p {}'.format(request))
         # hack to see if this dagrun has manually been marked through the UI.
         # if so, we also want to update the unfinished tasks
         if 'edit_view' not in '\n'.join(traceback.format_stack()):

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4747,11 +4747,8 @@ class DagRun(Base, LoggingMixin):
     def set_state(self, state):
         if self._state != state:
             self._state = state
-            if state == State.FAILED:
-                import traceback
-                print("hi kirolos")
-                traceback.print_stack()
-            #     self.fail_unfinished_tasks()
+            if state == State.FAILED and self.external_trigger:
+                self.fail_unfinished_tasks()
             if self.dag_id is not None:
                 # FIXME: Due to the scoped_session factor we we don't get a clean
                 # session here, so something really weird goes on:

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4735,7 +4735,7 @@ class DagRun(Base, LoggingMixin):
         return self._state
 
     def _fail_unfinished_tasks(self, target_state):
-        print(repr(g))
+        print('flask-g {}'.format(repr(g)))
         # hack to see if this dagrun has manually been marked through the UI.
         # if so, we also want to update the unfinished tasks
         if 'edit_view' not in '\n'.join(traceback.format_stack()):

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4735,7 +4735,7 @@ class DagRun(Base, LoggingMixin):
         return self._state
 
     def _fail_unfinished_tasks(self, target_state):
-        print('flask-g {}'.format(repr(g)))
+        print('flask-g {}'.format(g))
         # hack to see if this dagrun has manually been marked through the UI.
         # if so, we also want to update the unfinished tasks
         if 'edit_view' not in '\n'.join(traceback.format_stack()):

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4735,20 +4735,20 @@ class DagRun(Base, LoggingMixin):
         return self._state
 
     @provide_session
-    def _fail_unfinished_tasks(self, session=None):
+    def _fail_unfinished_tasks(self, target_state, session=None):
         # hack to see if this dag has manually been marked as failed through the UI.
         # if so, we also want to fail unfinished tasks
         if 'edit_view' not in '\n'.join(traceback.format_stack()):
             return
         unfinished_tasks = self.get_task_instances(state=State.unfinished(), session=session)
         for ut in unfinished_tasks:
-            ut.set_state(State.FAILED, session=session)
+            ut.set_state(target_state, session=session)
 
     def set_state(self, state):
         if self._state != state:
             self._state = state
             if state in [State.FAILED, State.SUCCESS]:
-                self._fail_unfinished_tasks()
+                self._fail_unfinished_tasks(state)
             if self.dag_id is not None:
                 # FIXME: Due to the scoped_session factor we we don't get a clean
                 # session here, so something really weird goes on:

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4747,7 +4747,7 @@ class DagRun(Base, LoggingMixin):
     def set_state(self, state):
         if self._state != state:
             self._state = state
-            if state == State.FAILED:
+            if state in [State.FAILED, State.SUCCESS]:
                 self._fail_unfinished_tasks()
             if self.dag_id is not None:
                 # FIXME: Due to the scoped_session factor we we don't get a clean

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4742,13 +4742,16 @@ class DagRun(Base, LoggingMixin):
             #     dep_context=DepContext(deps=SCHEDULER_DEPS)
             # )
             # if not deps_met:
-            ut.set_state(State.FAILED, session=None)
+            ut.set_state(State.FAILED, session=session)
 
     def set_state(self, state):
         if self._state != state:
             self._state = state
-            # if state == State.FAILED:
-            #     self._fail_unfinished_tasks()
+            if state == State.FAILED:
+                import traceback
+                print("hi kirolos")
+                traceback.print_stack()
+            #     self.fail_unfinished_tasks()
             if self.dag_id is not None:
                 # FIXME: Due to the scoped_session factor we we don't get a clean
                 # session here, so something really weird goes on:

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -83,7 +83,7 @@ from airflow.utils.state import State
 from airflow.utils.timeout import timeout
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.log.logging_mixin import LoggingMixin
-
+from flask import g
 Base = declarative_base()
 ID_LEN = 250
 XCOM_RETURN_KEY = 'return_value'
@@ -4735,6 +4735,7 @@ class DagRun(Base, LoggingMixin):
         return self._state
 
     def _fail_unfinished_tasks(self, target_state):
+        print(repr(g))
         # hack to see if this dagrun has manually been marked through the UI.
         # if so, we also want to update the unfinished tasks
         if 'edit_view' not in '\n'.join(traceback.format_stack()):

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2422,6 +2422,8 @@ class DagRunModelView(ModelViewOnly):
                 dirty_ids.append(dr.dag_id)
                 count += 1
                 dr.state = target_state
+                if target_state == State.FAILED:
+                    dr.fail_unfinished_tasks()
                 if target_state == State.RUNNING:
                     dr.start_date = datetime.utcnow()
                 else:

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2422,8 +2422,6 @@ class DagRunModelView(ModelViewOnly):
                 dirty_ids.append(dr.dag_id)
                 count += 1
                 dr.state = target_state
-                if target_state == State.FAILED:
-                    dr.fail_unfinished_tasks()
                 if target_state == State.RUNNING:
                     dr.start_date = datetime.utcnow()
                 else:


### PR DESCRIPTION
When a dagrun's state is manually changed to either `success` or `failed` from the `edit` page, task instances that are unfinished do not get transitioned to `failed` or `succeeded`, but rather just get a null state. This clogs up the scheduler when it ticks and delays task runs in the future. Fix that