### PR TITLE
[PROD-26871] Mark tasks as failed

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2385,6 +2385,18 @@ class DagRunModelView(ModelViewOnly):
         start_date=datetime_f,
         dag_id=dag_link)
 
+    @expose('/edit/', methods=('GET', 'POST'))
+    def edit_view(self):
+        return_value = super(DagRunModelView, self).edit_view()
+        if request and request.method == 'POST' and request.form.get('state') in [State.SUCCESS, State.FAILED]:
+            dag_id = request.form.get('dag_id')
+            execution_date = request.form.get('execution_date')
+            execution_date = dateutil.parser.parse(execution_date)
+            dag = dagbag.get_dag(dag_id)
+            new_dag_state = set_dag_run_state(dag, execution_date, state=request.form.get('state'), commit=True)
+            flash('Marked {} DAGs as {}'.format(len(new_dag_state), request.form.get('state')))
+        return return_value
+
     @action('new_delete', "Delete", "Are you sure you want to delete selected records?")
     @provide_session
     def action_new_delete(self, ids, session=None):

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2388,7 +2388,7 @@ class DagRunModelView(ModelViewOnly):
     @expose('/edit/', methods=('GET', 'POST'))
     def edit_view(self):
         return_value = super(DagRunModelView, self).edit_view()
-        if request and request.method == 'POST' and request.form.get('state') in [State.SUCCESS, State.FAILED]:
+        if request and request.method == 'POST':
             dag_id = request.form.get('dag_id')
             execution_date = request.form.get('execution_date')
             execution_date = dateutil.parser.parse(execution_date)


### PR DESCRIPTION
When a DagRun is manually marked as {failed, success} in the UI, we want to also update it's tasks because they otherwise clog up the scheduler. This accomplishes that easily explainable, yet very tedious task. 😡 